### PR TITLE
Concourse 3.7.0

### DIFF
--- a/base/params.yml
+++ b/base/params.yml
@@ -1,13 +1,16 @@
 ---
 params:
-  ssl_pem:           (( vault meta.vault "/ssl/server:combined" ))
   external_domain:   (( param "Please specify the IP/DNS users will use to connect to Concourse" ))
+  num_web_nodes:     (( param "Please specify the number of web nodes you want to allocate" ))
   external_url:      (( concat "https://" params.external_domain ))
   concourse_network: concourse
   concourse_vm_type: small
   concourse_disk_type: concourse
   stemcell_os: ubuntu-trusty
   stemcell_version: latest
+  token_signing_key:
+    public_key: (( vault meta.vault "/atc/token_signing_key:public" ))
+    private_key: (( vault meta.vault "/atc/token_signing_key:private" ))
 
   availability_zones:
   - z1

--- a/base/params.yml
+++ b/base/params.yml
@@ -1,7 +1,7 @@
 ---
 params:
   external_domain:   (( param "Please specify the IP/DNS users will use to connect to Concourse" ))
-  num_web_nodes:     (( param "Please specify the number of web nodes you want to allocate" ))
+  num_web_nodes:     1
   external_url:      (( concat "https://" params.external_domain ))
   concourse_network: concourse
   concourse_vm_type: small

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -16,19 +16,25 @@ instance_groups:
         name: haproxy
         properties:
           ha_proxy:
-            backend_port: 8080
-            backend_servers: (( grab instance_groups.web.networks.0.static_ips ))
-            ssl_pem: (( grab params.ssl_pem ))
-            https_redirect_all: true
+            tcp:
+            - name: web_http
+              port: 80
+              backend_port: (( grab instance_groups.web.jobs.atc.bind_port ))
+              backend_servers: (( grab instance_groups.web.networks.0.static_ips ))
+            - name: web_https
+              port: 443
+              backend_port: (( grab instance_groups.web.jobs.atc.tls_bind_port ))
+              backend_servers: (( grab instance_groups.web.networks.0.static_ips ))
+              backend_ssl: noverify
 
   - name: web
-    instances: 1
+    instances: (( grab params.num_web_nodes ))
     azs: (( grab params.availability_zones ))
     stemcell: default
     vm_type: (( grab params.concourse_vm_type ))
     networks:
     - name: (( grab params.concourse_network ))
-      static_ips: (( static_ips 1, 2 ))
+      static_ips: (( static_ips 1, 2, 3, 4, 5 ))
     jobs:
       - release: concourse
         name: tsa
@@ -37,9 +43,7 @@ instance_groups:
           host_public_key: (( vault meta.vault "/tsa/host_key:public" ))
           authorized_keys:
           - (( vault meta.vault "/tsa/worker_key:public" ))
-          token_signing_key: 
-            public_key: (( vault meta.vault "/atc/token_signing_key:public" ))
-            private_key: (( vault meta.vault "/atc/token_signing_key:private" ))
+          token_signing_key: (( grab params.token_signing_key ))
       - release: concourse
         name: atc
         properties:
@@ -48,10 +52,11 @@ instance_groups:
             role:
               name: atc
               password: (( vault meta.vault "/database/atc:password" ))
-          token_signing_key:
-            public_key: (( vault meta.vault "/atc/token_signing_key:public" ))
-            private_key: (( vault meta.vault "/atc/token_signing_key:private" ))
+          token_signing_key: (( grab params.token_signing_key ))
           bind_port: 8080
+          tls_bind_port: 4443
+          tls_cert: (( vault meta.vault "/ssl/server:certificate" ))
+          tls_key:  (( vault meta.vault "/ssl/server:key" ))
           publicly_viewable: true
           basic_auth_username: concourse
           basic_auth_password: (( vault meta.vault "/webui:password" ))
@@ -64,7 +69,6 @@ instance_groups:
     vm_type: (( grab params.concourse_vm_type ))
     networks:
     - name: (( grab params.concourse_network ))
-      static_ips: (( static_ips 3 ))
     persistent_disk_pool: (( grab params.concourse_disk_type ))
     jobs:
     - name: postgres

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -19,13 +19,12 @@ instance_groups:
             tcp:
             - name: web_http
               port: 80
-              backend_port: (( grab instance_groups.web.jobs.atc.bind_port ))
+              backend_port: (( grab instance_groups.web.jobs.atc.properties.bind_port ))
               backend_servers: (( grab instance_groups.web.networks.0.static_ips ))
             - name: web_https
               port: 443
-              backend_port: (( grab instance_groups.web.jobs.atc.tls_bind_port ))
+              backend_port: (( grab instance_groups.web.jobs.atc.properties.tls_bind_port ))
               backend_servers: (( grab instance_groups.web.networks.0.static_ips ))
-              backend_ssl: noverify
 
   - name: web
     instances: (( grab params.num_web_nodes ))
@@ -39,8 +38,9 @@ instance_groups:
       - release: concourse
         name: tsa
         properties:
-          host_key: (( vault meta.vault "/tsa/host_key:private" ))
-          host_public_key: (( vault meta.vault "/tsa/host_key:public" ))
+          host_key: 
+            private_key: (( vault meta.vault "/tsa/host_key:private" ))
+            public_key: (( vault meta.vault "/tsa/host_key:public" ))
           authorized_keys:
           - (( vault meta.vault "/tsa/worker_key:public" ))
           token_signing_key: (( grab params.token_signing_key ))
@@ -105,8 +105,9 @@ instance_groups:
         name: groundcrew
         properties:
           tsa:
-            private_key: (( vault meta.vault "/tsa/worker_key:private" ))
-            host_public_key: (( vault meta.vault "/tsa/host_key:public" ))
+            worker_key:
+              private_key: (( vault meta.vault "/tsa/worker_key:private" ))
+              public_key: (( vault meta.vault "/tsa/worker_key:public" ))
       - release: concourse
         name: baggageclaim
         properties: {}

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -37,7 +37,9 @@ instance_groups:
           host_public_key: (( vault meta.vault "/tsa/host_key:public" ))
           authorized_keys:
           - (( vault meta.vault "/tsa/worker_key:public" ))
-          authorize_generated_worker_key: false
+          token_signing_key: 
+            public_key: (( vault meta.vault "/atc/token_signing_key:public" ))
+            private_key: (( vault meta.vault "/atc/token_signing_key:private" ))
       - release: concourse
         name: atc
         properties:
@@ -46,6 +48,9 @@ instance_groups:
             role:
               name: atc
               password: (( vault meta.vault "/database/atc:password" ))
+          token_signing_key:
+            public_key: (( vault meta.vault "/atc/token_signing_key:public" ))
+            private_key: (( vault meta.vault "/atc/token_signing_key:private" ))
           bind_port: 8080
           publicly_viewable: true
           basic_auth_username: concourse
@@ -119,9 +124,9 @@ update:
 
 releases:
 - name: concourse
-  sha1: 1257bdcd3181ab0a669bc9e34cd87aff584f007b
-  url: https://bosh.io/d/github.com/concourse/concourse?v=3.6.0
-  version: 3.6.0
+  sha1: 20e17e3ac079f1b1a5095329a4fb14de40317bb9
+  url: https://bosh.io/d/github.com/concourse/concourse?v=3.7.0
+  version: 3.7.0
 - name: postgres
   sha1: 3f378bcab294e20316171d4e656636df88763664
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=20

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -116,8 +116,6 @@ instance_groups:
           garden:
             listen_network: tcp
             listen_address: 0.0.0.0:7777
-            enable_graph_cleanup: true
-
 
 update:
   canaries: 1

--- a/kit.yml
+++ b/kit.yml
@@ -165,6 +165,8 @@ credentials:
     tsa/host_key: ssh 2048 fixed
     tsa/worker_key: ssh 2048 fixed
 
+    atc/token_signing_key: rsa 2048 fixed
+
     locker/api:
       password: random 16
 

--- a/kit.yml
+++ b/kit.yml
@@ -39,7 +39,7 @@ params:
     - ask: How many web frontend nodes would you like to deploy and load balance between?
       description: The number of instances of web nodes to allocate.
       param: num_web_nodes
-      validate: 1-5
+      validate: 1,2,3,4,5
 
   provided-cert:
     - ask: What is the SSL cert + key pair for Concourse?

--- a/kit.yml
+++ b/kit.yml
@@ -36,7 +36,7 @@ params:
         Do not include 'https://' in this value.
       param: external_domain
 
-    - ask: How many web frontend nodes would you like to deploy and load balance between?
+    - ask: How many web frontend nodes would you like to deploy and load balance between (max 5)?
       description: The number of instances of web nodes to allocate.
       param: num_web_nodes
       validate: 1,2,3,4,5

--- a/kit.yml
+++ b/kit.yml
@@ -36,6 +36,11 @@ params:
         Do not include 'https://' in this value.
       param: external_domain
 
+    - ask: How many web frontend nodes would you like to deploy and load balance between?
+      description: The number of instances of web nodes to allocate.
+      param: num_web_nodes
+      validate: 1-5
+
   provided-cert:
     - ask: What is the SSL cert + key pair for Concourse?
       type: multi-line


### PR DESCRIPTION
* Bumps to Concourse 3.7.0
* Uses Concourse's own TLS termination instead of at the HAProxy level to avoid confusing Fly (and by extension, confusing the operator) when you try to talk to Concourse with plebeian HTTP unencrypted slop.
* The kit now asks how many web nodes you want. We also now support having up to 5 web nodes.