### PR TITLE
Support multiple *_vm_type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,40 @@ Params
 #### Base Params
 
 - **params.external_url** - This is the external URL that users will use to access Concourse.
+
 - **SSL PEM** - Concourse requires an SSL certificate to be accessed using https. This should
   be a PEM file containing the SSL certificate + Private Key. The data will be stored in Vault
   under `secret/path/to/env/concourse/ssl:combined`.
+
+- **params.concourse_vm_type** - The `vm_type` to use for all
+  Concourse VMs, by default.  For any serious pipeline usage, you
+  will want to also set **params.worker_vm_type**, to get more
+  ephemeral disk for the workers.  Defaults to `concourse`.
+
+- **params.haproxy_vm_type** - The `vm_type` to use for haproxy
+  VMs, if you are deploying those.  Defaults to whatever
+  **params.concourse_vm_type** has been set to.
+
+- **params.web_vm_type** - The `vm_type` to use for web (TSA /
+  ATC) nodes.  Defaults to whatever **params.concourse_vm_type**
+  has been set to.
+
+- **params.db_vm_type** - The `vm_type` to use for the database
+  node.  Defaults to whatever **params.concourse_vm_type** has
+  been set to.
+
+- **params.worker_vm_type** - The `vm_type` to use for workers.
+  Defaults to whatever **params.concourse_vm_type** has been set
+  to, which may not be the best.
+
+- **params.concourse_network** - The name of the BOSH cloud-config
+  network that Concourse will be deployed into.  Defaults to
+  `concourse`.
+
+- **params.concourse_disk_type** - The `disk_type` is used only on
+  the database node, for sizing the persistent disk which will
+  house all of our build logs and pipeline output.
+
 
 #### github-oauth Params
 

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -32,7 +32,7 @@ instance_groups:
     instances: 1
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    vm_type: (( grab params.concourse_vm_type ))
+    vm_type: (( grab params.haproxy_vm_type || params.concourse_vm_type ))
     networks:
     - name: (( grab params.concourse_network ))
       static_ips: (( static_ips 0 ))
@@ -55,7 +55,7 @@ instance_groups:
     instances: (( grab params.num_web_nodes ))
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    vm_type: (( grab params.concourse_vm_type ))
+    vm_type: (( grab params.web_vm_type || params.concourse_vm_type ))
     networks:
     - name: (( grab params.concourse_network ))
       static_ips: (( static_ips 1, 2, 4, 5, 6 ))
@@ -91,7 +91,7 @@ instance_groups:
     instances: 1
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    vm_type: (( grab params.concourse_vm_type ))
+    vm_type: (( grab params.db_vm_type || params.concourse_vm_type ))
     networks:
     - name: (( grab params.concourse_network ))
     persistent_disk_pool: (( grab params.concourse_disk_type ))
@@ -119,7 +119,7 @@ instance_groups:
     instances: (( grab params.workers ))
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    vm_type: (( grab params.concourse_vm_type ))
+    vm_type: (( grab params.worker_vm_type || params.concourse_vm_type ))
     networks:
     - name: (( grab params.concourse_network ))
     update:

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Improvements
+
+- New, per-instance-group VM type parameters, to make it easier to
+  resize your worker VMs with larger ephemeral disks, without
+  affecting things like the haproxy nodes or the database.


### PR DESCRIPTION
This makes it easier to size things like workers, without also
(inadvertantly) resizing your database or haproxy nodes.