### PR TITLE
Fixes for Bash 4.x handling of uninitialized arrays

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -21,6 +21,7 @@ if want_feature "full" ; then
   merge+=( "manifests/concourse-full.yml" )
 
   declare -a oauths
+  oauths=()
   for oauth in "github-oauth" "github-enterprise-oauth" "cf-oauth" ; do
     if want_feature "$oauth" ; then
       oauths+=( "$oauth" )

--- a/hooks/new
+++ b/hooks/new
@@ -8,6 +8,7 @@ prefix="$GENESIS_VAULT_PREFIX"
 
 ymlfile="$dir/$name.yml"
 declare -a features
+features=()
 params="\\nparams:\\n  env:   $name\\n  vault: $prefix\\n"
 
 describe "" \


### PR DESCRIPTION
Bash 4 doesn't like declared but uninitialized arrays, so we need to initialize them to empty