### PR TITLE
Update worker VM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Params
   been set to.
 
 - **params.worker_vm_type** - The `vm_type` to use for workers.
-  Defaults to whatever **params.concourse_vm_type** has been set
-  to, which may not be the best.
+  Defaults to VM type `concourse-worker`, which you can define 
+  in your cloud config. Recommended values are 8GB of RAM and 
+  60GB of disk.
 
 - **params.concourse_network** - The name of the BOSH cloud-config
   network that Concourse will be deployed into.  Defaults to
@@ -187,6 +188,7 @@ params:
   concourse_network:   concourse
   concourse_disk_pool: concourse # should be at least 10GB (used for the concourse DB)
   concourse_vm_type:   small # VMs should have at least 2 CPUs, and 4GB of memory
+  worker_vm_type:      concourse # VMs should have 8GB of memory and 60GB of disk.
 ```
 
 [1]: https://concourse.ci

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -27,7 +27,7 @@ instance_groups:
     instances: (( grab params.workers ))
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    vm_type: (( grab params.worker_vm_type || concourse-worker ))
+    vm_type: (( grab params.worker_vm_type || "concourse-worker" ))
     networks:
     - name: (( grab params.concourse_network ))
     update:

--- a/manifests/concourse-base.yml
+++ b/manifests/concourse-base.yml
@@ -27,7 +27,7 @@ instance_groups:
     instances: (( grab params.workers ))
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    vm_type: (( grab params.worker_vm_type || params.concourse_vm_type ))
+    vm_type: (( grab params.worker_vm_type || concourse-worker ))
     networks:
     - name: (( grab params.concourse_network ))
     update:


### PR DESCRIPTION
This is a PR based off the input from James on #23. It changes the default worker_vm_type to a to-be-defined-in-cloud-config value named `concourse-worker`. I've updated the documentation to reflect these changes.