### PR TITLE
Allow Github OAuth2 authz to be overridden

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -109,6 +109,11 @@ provide the following parameters:
     For legacy reasons, it retains a pluralization of its name, but only
     allows a single organization.  This parameter is **required**.
 
+  - `github_authz` - A list of authorizations to determine who is
+    allowed to authenticate. This supersedes `authz_allowed_orgs`,
+    and lets you grant individual teams and users access,
+    regardless of their org memberships.
+
 The following secrets will be pulled from the vault:
 
   - **Oauth2 Client ID and Secret** - The Client ID and secret of the Github

--- a/manifests/oauth/github-enterprise-oauth.yml
+++ b/manifests/oauth/github-enterprise-oauth.yml
@@ -5,6 +5,12 @@ params:
   github_token_url:   (( param "Please provide the URL to your GitHub Enterprise token endpoint" ))
   github_auth_url:    (( param "Please provide the URL to your GitHub Enterprise OAuth endpoint" ))
 
+meta:
+  default:
+    github_authz:
+      - organization: (( grab params.authz_allowed_orgs ))
+        teams:        all
+
 instance_groups:
   - name: web
     jobs:
@@ -13,11 +19,9 @@ instance_groups:
         basic_auth_username: (( prune ))
         basic_auth_password: (( prune ))
         github_auth:
-          authorize:
-          - organization: (( grab params.authz_allowed_orgs ))
-            teams: all
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))
+          authorize:     (( grab params.github_authz || meta.default.github_authz ))
           api_url:       (( grab params.github_api_url ))
           auth_url:      (( grab params.github_auth_url ))
           token_url:     (( grab params.github_token_url ))

--- a/manifests/oauth/github-oauth.yml
+++ b/manifests/oauth/github-oauth.yml
@@ -2,6 +2,12 @@
 params:
   authz_allowed_orgs: (( param "Please provide the name of the organization authorized for using Concourse" ))
 
+meta:
+  default:
+    github_authz:
+      - organization: (( grab params.authz_allowed_orgs ))
+        teams:        all
+
 instance_groups:
   - name: web
     jobs:
@@ -10,8 +16,6 @@ instance_groups:
         basic_auth_username: (( prune ))
         basic_auth_password: (( prune ))
         github_auth:
-          authorize:
-          - organization: (( grab params.authz_allowed_orgs ))
-            teams: all
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))
+          authorize:     (( grab params.github_authz || meta.default.github_authz ))


### PR DESCRIPTION
Fixes #21.

The new `github_authz` property allows you to set fine-grained access
control, to give specific teams and/or users to access the Concourse.