### PR TITLE
Add `setup-approle` to automatically create a Vault AppRole & policy

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -344,3 +344,6 @@ params:
 for addon scripts and `genesis info`.
 
 2.2.1 was the first version to incorporate Shout!
+
+2.2.2 added an addon command to setup an AppRole and policy for Genesis
+Concourse deployments.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -2,6 +2,9 @@
 
 - New `shout` feature for enabling a centralized notifications
   gateway for pipelines.
+- Added a `setup-approle` addon that allows operators to 
+  easily generate a new AppRole and policy for use with the 
+  Concourse pipelines Genesis can generate.
 
 # Bug Fixes
 

--- a/hooks/addon
+++ b/hooks/addon
@@ -249,8 +249,8 @@ setup-approle)
 
 
   # write info to exodus
-  safe --quiet set secret/exodus/ci/genesis_pipelines approle_id=$role_id
-  safe --quiet set secret/exodus/ci/genesis_pipelines approle_secret=$approle_secret
+  safe --quiet set secret/exodus/ci/genesis-pipelines approle-id=$role_id
+  safe --quiet set secret/exodus/ci/genesis-pipelines approle-secret=$approle_secret
 
   safe --quiet vault policy write genesis-pipelines -<<EOF
 # Allow the pipelines to read all items within Vault, and write to secret/exodus (for genesis exodus data)

--- a/hooks/addon
+++ b/hooks/addon
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+vault="secret/$GENESIS_VAULT_PREFIX"
 
 error() {
   describe >&2 "" "$@" ""
@@ -148,6 +149,9 @@ list() {
   echo
   echo "  fly                  Run fly commands targetting this Concourse Deployment"
   echo
+  echo "  setup-approle        Create the necessary Vault AppRole and policy for Genesis"
+  echo "                       Concourse deployments."
+  echo
 }
 
 # MAIN
@@ -216,6 +220,51 @@ fly)
   fly -t "$host_env" "$@"
   echo
   exit $?
+  ;;
+
+setup-approle)
+  # If AppRole is already enabled in this Vault, it'll return a 400 error with "path already in use". This is OK.
+  if [[ ! $(safe vault auth enable approle 2>&1) =~ (Success\! Enabled approle auth method)|(path is already in use) ]] ; then
+    echo "Failed to enable AppRole on your targeted Vault. Womp womp :("
+    exit 1
+  fi
+
+  if ! safe exists "secret/exodus/$GENESIS_ENVIRONMENT/concourse" ; then
+    error "#R{[ERROR]} Cannot find exodus data for #C{$GENESIS_ENVIRONMENT}.  Please redeploy" \
+          "        before using addons."
+  fi
+
+  # Create AppRole Role named "genesis-piplines" with the following parameters:
+  # - 90 minute TTL (Some BOSH deployments could take awhile, and then the Exodus write-back could fail if TTL is too short)
+  # - unlimited token use
+  safe --quiet set auth/approle/role/genesis-pipelines \
+    secret_id_ttl=90m \
+    token_num_uses=0 \
+    token_ttl=90m \
+    token_max_ttl=90m \
+    secret_id_num_uses=0
+  role_id=$(safe get auth/approle/role/genesis-pipelines/role-id:role_id)
+  # generate a secret key for the newly minted role
+  approle_secret=$(safe vault write -field=secret_id -f auth/approle/role/genesis-pipelines/secret-id)
+
+
+  # write info to exodus
+  safe --quiet set $vault/genesis_pipelines approle_id=$role_id
+  safe --quiet set $vault/genesis_pipelines approle_secret=$approle_secret
+
+  safe --quiet vault policy write genesis-pipelines -<<EOF
+# Allow the pipelines to read all items within Vault, and write to secret/exodus (for genesis exodus data)
+path "secret/*" {
+  capabilities = ["read", "list"]
+}
+
+path "secret/exodus/*" {
+    capabilities = ["create", "read", "update", "list", "delete"]
+}
+EOF
+
+  safe --quiet set auth/approle/role/genesis-pipelines policies=default,genesis-pipelines
+  exit 0
   ;;
 
 *)

--- a/hooks/addon
+++ b/hooks/addon
@@ -249,8 +249,8 @@ setup-approle)
 
 
   # write info to exodus
-  safe --quiet set $vault/genesis_pipelines approle_id=$role_id
-  safe --quiet set $vault/genesis_pipelines approle_secret=$approle_secret
+  safe --quiet set secret/exodus/ci/genesis_pipelines approle_id=$role_id
+  safe --quiet set secret/exodus/ci/genesis_pipelines approle_secret=$approle_secret
 
   safe --quiet vault policy write genesis-pipelines -<<EOF
 # Allow the pipelines to read all items within Vault, and write to secret/exodus (for genesis exodus data)


### PR DESCRIPTION
This PR adds a new addon command called `setup-approle`, which creates an AppRole named `genesis-pipelines` with the policy `genesis-pipelines` that grants read access to `secret/*` and write access to `secret/exodus/*`. It then adds this information to the Concourse vault path.

In a future version of Genesis (soon), `genesis repipe` will automatically grab this information from the Vault rather than requiring an operator to extract these creds and place them into `ci.yml`.