### PR TITLE
Concourse4

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,30 @@
+# Release Changes
+
+* Bumped Concourse to 4.2.3
+* Bumped Garden RunC to 1.18.3
+* Bumped Postgres to 31
+
+# Upgrading (IMPORTANT)
+
+Hey! If you're not careful, you can break your Concourse during this upgrade!
+Read this: [GMP-CONCOURSE-0001](https://genesisproject.io/docs/migrations/gmp-concourse-0001/)
+
+As additional notes, you'll likely need to run `genesis add secrets` before
+deploying so that Genesis can generate a bcrypt of your existing password.
+
+# Bug Fixes
+
+In the last release, there was a regression where you couldn't directly
+override properties of jobs in the manifest. It's fixed now.
+
+# Core Components
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ | 
+| Concourse | [4.2.3](https://github.com/concourse/concourse-bosh-release/releases/tag/v4.2.3) | Feb 25, 2019 |
+| Garden RunC | [1.18.3](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.18.3) | Feb 18, 2019 |
+| Postgres | [31](https://github.com/cloudfoundry/postgres-release/releases/tag/v31) | Nov 19, 2018 |
+| Slack Notification Resource | [9](https://github.com/cloudfoundry-community-attic/slack-notification-resource-boshrelease/releases/tag/v9) | Feb 19, 2016 |
+| Shout | [0.1.0](https://github.com/jhunt/shout-boshrelease/releases/tag/v0.1.0) | Sep 3, 2018 |
+| Locker | [0.2.1](https://github.com/cloudfoundry-community/locker-boshrelease/releases/tag/v0.2.1) | May 31, 2017 |
+| HAProxy | [8.4.2](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v8.4.2) | Oct 29, 2017 |

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -44,18 +44,18 @@ if want_feature "full" || want_feature "small-footprint"; then
     merge+=( "manifests/concourse/small-footprint.yml" )
   fi
 
-  declare -a oauths
-  oauths=()
-  for oauth in "github-oauth" "github-enterprise-oauth" "cf-oauth" ; do
+  for oauth in "github-oauth" "cf-oauth" ; do
     if want_feature "$oauth" ; then
-      oauths+=( "$oauth" )
       merge+=( "manifests/oauth/${oauth}.yml" )
     fi
   done
-  if [[ "${#oauths[@]}" -gt 1 ]] ; then
-    echo >&2 "You have requested multiple oauth systems:"
-    echo >&2 "  ${oauths[*]}"
-    echo >&2 "Please pick up to one (uses http basic auth if none selected)"
+
+  if want_feature "github-enterprise-oauth"; then
+    # github enterprise oauth just adds the host param to github oauth
+    if ! want_feature "github-oauth"; then
+      merge+=( "manifests/oauth/github-oauth.yml" )
+    fi
+    merge+=( "manifests/oauth/github-enterprise-oauth.yml" )
   fi
 
   if ! want_feature no-tls ; then

--- a/kit.yml
+++ b/kit.yml
@@ -33,7 +33,7 @@ credentials:
       password: random 64
 
     webui:
-      password: random 16
+      password: random 16 fmt bcrypt
 
   shout:
     shout/ops:

--- a/manifests/concourse/base.yml
+++ b/manifests/concourse/base.yml
@@ -36,21 +36,8 @@ instance_groups:
       serial: true
       max_in_flight: (( grab instance_groups.worker.instances ))
     jobs:
-    - release: concourse
-      name: worker
-      properties:
-        http_proxy_url:  (( grab params.http_proxy  || "" ))
-        https_proxy_url: (( grab params.https_proxy || "" ))
-        no_proxy:        (( grab params.no_proxy    || meta.default.no_proxy ))
-        tsa:
-          registration_mode: forward
-          worker_key:
-            private_key: (( vault meta.vault "/tsa/worker_key:private" ))
-            public_key: (( vault meta.vault "/tsa/worker_key:public" ))
-        baggageclaim:
-          forward_address: 127.0.0.1:7788
-        garden:
-          forward_address: 127.0.0.1:7777
+    - name: worker
+      .: (( inject meta.jobs.worker ))
     - release: concourse
       name: baggageclaim
       properties:
@@ -63,10 +50,12 @@ instance_groups:
           listen_address: 0.0.0.0:7777
 
 releases:
-- (( prepend ))
-- (( grab meta.releases.concourse ))
-- (( grab meta.releases.garden ))
-- (( grab meta.releases.slack-notifications ))
+  - name: concourse
+    .: (( inject meta.releases.concourse ))
+  - name: garden-runc
+    .: (( inject meta.releases.garden ))
+  - name: slack-notification-resource
+    .: (( inject meta.releases.slack-notifications ))
 
 stemcells:
 - alias: default

--- a/manifests/concourse/base.yml
+++ b/manifests/concourse/base.yml
@@ -43,6 +43,7 @@ instance_groups:
         https_proxy_url: (( grab params.https_proxy || "" ))
         no_proxy:        (( grab params.no_proxy    || meta.default.no_proxy ))
         tsa:
+          registration_mode: forward
           worker_key:
             private_key: (( vault meta.vault "/tsa/worker_key:private" ))
             public_key: (( vault meta.vault "/tsa/worker_key:public" ))

--- a/manifests/concourse/full.yml
+++ b/manifests/concourse/full.yml
@@ -36,7 +36,8 @@ instance_groups:
       - name: (( grab params.concourse_network ))
         static_ips: (( static_ips 0 ))
     jobs:
-      - (( grab meta.jobs.haproxy ))
+      - name: haproxy
+        .: (( inject meta.jobs.haproxy ))
   - name: web
     instances: (( grab params.num_web_nodes ))
     azs: (( grab params.availability_zones || meta.default.azs ))

--- a/manifests/concourse/full.yml
+++ b/manifests/concourse/full.yml
@@ -46,8 +46,10 @@ instance_groups:
       - name: (( grab params.concourse_network ))
         static_ips: (( static_ips 1, 2, 4, 5, 6 ))
     jobs:
-      - (( grab meta.jobs.atc ))
-      - (( grab meta.jobs.tsa ))
+      - name: atc
+        .: (( inject meta.jobs.atc ))
+      - name: tsa
+        .: (( inject meta.jobs.tsa ))
   - name: db
     instances: 1
     azs: (( grab params.availability_zones || meta.default.azs ))
@@ -57,11 +59,15 @@ instance_groups:
     - name: (( grab params.concourse_network ))
     persistent_disk_pool: (( grab params.concourse_disk_type ))
     jobs:
-      - (( grab meta.jobs.postgres ))
-      - (( grab meta.jobs.locker   ))
+      - name: postgres
+        .: (( inject meta.jobs.postgres ))
+      - name: locker
+        .: (( inject meta.jobs.locker ))
 
 releases:
-- (( append ))
-- (( grab meta.releases.postgres ))
-- (( grab meta.releases.locker   ))
-- (( grab meta.releases.haproxy  ))
+  - name: postgres
+    .: (( inject meta.releases.postgres ))
+  - name: locker
+    .: (( inject meta.releases.locker   ))
+  - name: haproxy
+    .: (( inject meta.releases.haproxy  ))

--- a/manifests/concourse/jobs.yml
+++ b/manifests/concourse/jobs.yml
@@ -4,7 +4,6 @@
 meta:
   jobs:
     haproxy:  
-      name: haproxy
       release: haproxy
       properties:
         ha_proxy:
@@ -15,7 +14,6 @@ meta:
               backend_servers: (( grab instance_groups.web.networks.0.static_ips || instance_groups.concourse.networks.0.static_ips ))
     atc:
       release: concourse
-      name: atc
       properties:
         postgresql:
           database: atc
@@ -35,7 +33,6 @@ meta:
         external_url: (( grab params.external_url ))
     tsa:
       release: concourse
-      name: tsa
       properties:
         host_key:
           private_key: (( vault meta.vault "/tsa/host_key:private" ))
@@ -44,7 +41,6 @@ meta:
         - (( vault meta.vault "/tsa/worker_key:public" ))
         token_signing_key: (( grab params.token_signing_key ))
     postgres:
-      name: postgres
       release: postgres
       properties:
         databases:
@@ -55,7 +51,6 @@ meta:
           - name: atc
             password: (( vault meta.vault "/database/atc:password" ))
     locker:
-      name: locker
       release: locker
       properties:
         locker:
@@ -65,7 +60,6 @@ meta:
           ssl_key: (( vault meta.vault "/locker/server:key" ))
     worker:
       release: concourse
-      name: worker
       properties:
         http_proxy_url:  (( grab params.http_proxy  || "" ))
         https_proxy_url: (( grab params.https_proxy || "" ))

--- a/manifests/concourse/jobs.yml
+++ b/manifests/concourse/jobs.yml
@@ -75,4 +75,4 @@ meta:
           forward_address: 127.0.0.1:7777
 
 
-  http_auth_password: (( vault meta.vault "/webui:password" ))
+  http_auth_password: (( vault meta.vault "/webui:password-bcrypt" ))

--- a/manifests/concourse/jobs.yml
+++ b/manifests/concourse/jobs.yml
@@ -25,8 +25,13 @@ meta:
         token_signing_key: (( grab params.token_signing_key ))
         bind_port: 8080
         publicly_viewable: true
-        basic_auth_username: (( grab params.main_user || meta.default.main_user ))
-        basic_auth_password: (( vault meta.vault "/webui:password" ))
+        main_team:
+          auth:
+            local:
+              users:
+                - (( grab params.main_user || meta.default.main_user ))
+        add_local_users:
+          - (( concat meta.jobs.atc.properties.main_team.auth.local.users.0 ":" meta.http_auth_password ))
         external_url: (( grab params.external_url ))
     tsa:
       release: concourse
@@ -66,6 +71,7 @@ meta:
         https_proxy_url: (( grab params.https_proxy || "" ))
         no_proxy:        (( grab params.no_proxy    || meta.default.no_proxy ))
         tsa:
+          registration_mode: forward
           worker_key:
             private_key: (( vault meta.vault "/tsa/worker_key:private" ))
             public_key: (( vault meta.vault "/tsa/worker_key:public" ))
@@ -73,3 +79,6 @@ meta:
           forward_address: 127.0.0.1:7788
         garden:
           forward_address: 127.0.0.1:7777
+
+
+  http_auth_password: (( vault meta.vault "/webui:password" ))

--- a/manifests/concourse/releases.yml
+++ b/manifests/concourse/releases.yml
@@ -3,14 +3,14 @@ meta:
   releases:
     concourse:
       name:    concourse
-      version: 3.14.1
-      sha1:    6be91b70ecc7ce233d2aff5d03ed28c8eab3d132
-      url:     https://bosh.io/d/github.com/concourse/concourse?v=3.14.1
+      version: 4.2.2
+      sha1:    4107747823b7056c58620c34457746dcedb98cc5
+      url:     https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=4.2.2
     garden:
       name:    garden-runc
-      version: 1.14.0
-      sha1:    be5e6d6a263be1437d99dc5e818deeb8ab2a03a4
-      url:     https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.14.0
+      version: 1.16.3
+      sha1:    2a7c813e7e4d862e19334addf022916fb6b91eb0
+      url:     https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.16.3
     slack-notifications:
       name:    slack-notification-resource
       version: 9
@@ -23,9 +23,9 @@ meta:
       url:     https://github.com/jhunt/shout-boshrelease/releases/download/v0.1.0/shout-0.1.0.tar.gz
     postgres:
       name:    postgres
-      version: 20
-      sha1:    3f378bcab294e20316171d4e656636df88763664
-      url:     https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=20
+      version: 31
+      sha1:    bbe4151f4000f349c2ffaf72412aac9cc0a3c741
+      url:     https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=31
     locker:
       name:    locker
       version: 0.2.1

--- a/manifests/concourse/releases.yml
+++ b/manifests/concourse/releases.yml
@@ -8,9 +8,9 @@ meta:
       url:     https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=4.2.3
     garden:
       name:    garden-runc
-      version: 1.16.3
-      sha1:    2a7c813e7e4d862e19334addf022916fb6b91eb0
-      url:     https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.16.3
+      version: 1.18.3
+      sha1:    1aa15e644c6c0c6c7ec072bf668fe5d9bcc4c632
+      url:     https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.18.3
     slack-notifications:
       name:    slack-notification-resource
       version: 9

--- a/manifests/concourse/releases.yml
+++ b/manifests/concourse/releases.yml
@@ -3,9 +3,9 @@ meta:
   releases:
     concourse:
       name:    concourse
-      version: 4.2.2
-      sha1:    4107747823b7056c58620c34457746dcedb98cc5
-      url:     https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=4.2.2
+      version: 4.2.3
+      sha1:    915ab6a3ea9fa8e611887e51630c7a4947dcd8c1
+      url:     https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=4.2.3
     garden:
       name:    garden-runc
       version: 1.16.3

--- a/manifests/concourse/small-footprint.yml
+++ b/manifests/concourse/small-footprint.yml
@@ -43,7 +43,9 @@ params:
     private_key:     (( vault meta.vault "/atc/token_signing_key:private" ))
 
 releases:
-- (( append ))
-- (( grab meta.releases.postgres ))
-- (( grab meta.releases.locker   ))
-- (( grab meta.releases.haproxy  ))
+  - name: postgres
+    .: (( inject meta.releases.postgres ))
+  - name: locker
+    .: (( inject meta.releases.locker   ))
+  - name: haproxy
+    .: (( inject meta.releases.haproxy  ))

--- a/manifests/concourse/small-footprint.yml
+++ b/manifests/concourse/small-footprint.yml
@@ -9,10 +9,14 @@ instance_groups:
       - name: (( grab params.concourse_network ))
         static_ips: (( static_ips 0 ))
     jobs:
-    - (( grab meta.jobs.postgres ))
-    - (( grab meta.jobs.locker   ))
-    - (( grab meta.jobs.tsa      ))
-    - .: (( inject meta.jobs.atc ))
+    - name: postgres
+      .: (( grab meta.jobs.postgres ))
+    - name: locker
+      .: (( grab meta.jobs.locker   ))
+    - name: tsa
+      .: (( grab meta.jobs.tsa      ))
+    - name: atc
+      .: (( inject meta.jobs.atc ))
       properties:
         bind_port: 80
 
@@ -47,5 +51,3 @@ releases:
     .: (( inject meta.releases.postgres ))
   - name: locker
     .: (( inject meta.releases.locker   ))
-  - name: haproxy
-    .: (( inject meta.releases.haproxy  ))

--- a/manifests/oauth/cf-oauth.yml
+++ b/manifests/oauth/cf-oauth.yml
@@ -5,7 +5,7 @@ params:
   cf_api_url:            (( param "Please provide the URL to your CF API" ))
   uaa_token_url:         (( param "Please provide the URL to your UAA Token endpoint" ))
   uaa_auth_url:          (( param "Please provide the URL to your UAA Auth endpoint" ))
-  cf_ca_cert_vault_path: (( param "Pleaes provide the Vault path that contains ca for the Cloud Foundry" ))
+  cf_ca_cert_vault_path: (( param "Please provide the Vault path that contains ca for the Cloud Foundry" ))
 
 
 
@@ -13,13 +13,12 @@ meta:
   jobs:
     atc:
       properties:
-        basic_auth_username: (( prune ))
-        basic_auth_password: (( prune ))
-        uaa_auth:
-          cf_spaces:     (( grab params.cf_spaces ))
+        main_team:
+          auth:
+            cf:
+              spaces: (( grab params.cf_spaces ))
+        cf_auth:
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))
-          cf_api_url:    (( grab params.cf_api_url ))
-          auth_url:      (( grab params.uaa_auth_url ))
-          token_url:     (( grab params.uaa_token_url ))
-          cf_ca_cert:    (( vault params.cf_ca_cert_vault_path ))
+          api_url:       (( grab params.cf_api_url ))
+          ca_cert:       (( vault params.cf_ca_cert_vault_path ))

--- a/manifests/oauth/github-enterprise-oauth.yml
+++ b/manifests/oauth/github-enterprise-oauth.yml
@@ -1,9 +1,7 @@
 ---
 params:
   authz_allowed_orgs: (( param "Please provide a list of org/teams/users authorized for using Concourse" ))
-  github_api_url:     (( param "Please provide the URL to your GitHub Enterprise API (requires trailing slash" ))
-  github_token_url:   (( param "Please provide the URL to your GitHub Enterprise token endpoint" ))
-  github_auth_url:    (( param "Please provide the URL to your GitHub Enterprise OAuth endpoint" ))
+  github_host:        (( param "Please provide the domain to your GitHub Enterprise installation"))
 
 meta:
   default:
@@ -15,12 +13,14 @@ meta:
   jobs:
     atc:
       properties:
-        basic_auth_username: (( prune ))
-        basic_auth_password: (( prune ))
+        add_local_users: (( prune ))
+        main_team:
+          auth:
+            local: (( prune ))
+            github:
+              orgs: (( grab params.authz_allowed_orgs || params.github.orgs ))
+
         github_auth:
+          host:          (( grab params.github_host))
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))
-          authorize:     (( grab params.github_authz || meta.default.github_authz ))
-          api_url:       (( grab params.github_api_url ))
-          auth_url:      (( grab params.github_auth_url ))
-          token_url:     (( grab params.github_token_url ))

--- a/manifests/oauth/github-enterprise-oauth.yml
+++ b/manifests/oauth/github-enterprise-oauth.yml
@@ -1,26 +1,11 @@
 ---
 params:
-  authz_allowed_orgs: (( param "Please provide a list of org/teams/users authorized for using Concourse" ))
-  github_host:        (( param "Please provide the domain to your GitHub Enterprise installation"))
-
-meta:
-  default:
-    github_authz:
-      - organization: (( grab params.authz_allowed_orgs ))
-        teams:        all
+  github_host: (( param "Please provide the domain to your GitHub Enterprise installation"))
 
 meta:
   jobs:
     atc:
       properties:
-        add_local_users: (( prune ))
-        main_team:
-          auth:
-            local: (( prune ))
-            github:
-              orgs: (( grab params.authz_allowed_orgs || params.github.orgs ))
-
         github_auth:
-          host:          (( grab params.github_host))
-          client_id:     (( vault meta.vault "/oauth:provider_key" ))
-          client_secret: (( vault meta.vault "/oauth:provider_secret" ))
+          #ca_cert: "SPECIFY THIS IF YOU NEED IT"
+          host:     (( grab params.github_host))

--- a/manifests/oauth/github-oauth.yml
+++ b/manifests/oauth/github-oauth.yml
@@ -12,9 +12,13 @@ meta:
   jobs:
     atc:
       properties:
-        basic_auth_username: (( prune ))
-        basic_auth_password: (( prune ))
+        add_local_users: (( prune ))
+        main_team:
+          auth:
+            local: (( prune ))
+            github:
+              orgs: [(( grab params.authz_allowed_orgs || params.github.orgs ))]
+
         github_auth:
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))
-          authorize:     (( grab params.github_authz || meta.default.github_authz ))

--- a/manifests/oauth/github-oauth.yml
+++ b/manifests/oauth/github-oauth.yml
@@ -12,10 +12,8 @@ meta:
   jobs:
     atc:
       properties:
-        add_local_users: (( prune ))
         main_team:
           auth:
-            local: (( prune ))
             github:
               orgs: [(( grab params.authz_allowed_orgs || params.github.orgs ))]
 


### PR DESCRIPTION
Notable things:
* This is Concourse 4.2.3. 
* We now support multiple authentication features, because this is how the authentication providers are configured with Concourse now - at deploy time. 
* All configured authentication methods are applied to the main team by default. This is sort of how it worked anyway in most cases - its just that the default `concourse` login will work even if Github is configured. This can always be manually overridden, and its not bad to have a failsafe for your admin team.
* There are some grab->inject changes to make overrides more intuitive - this was a regression in the last kit version.
* This upgrade doesn't require the user to provide any extra params to the env yaml. The only changes that would need to be made would be to manual overrides of auth information.