### PR TITLE
improving  github enterprise oauth

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -139,7 +139,8 @@ To hook up to an Enterprise Github installation, enable the
 parameters (above and beyond those required by `github-oauth`):
 
   - `github_host` - Domain of the Github Enterprise installation; something like
-    `https://github.example.com`.  This parameter is **required**.
+    `github.example.com`. No scheme, no trailing slash. This parameter is
+    **required**.
 
 ## Cloud Foundry UAA OAuth2-based Authentication
 

--- a/hooks/new
+++ b/hooks/new
@@ -69,22 +69,9 @@ if [[ "$kit_type" == "full" ]] ; then
       param_entry params authz_allowed_orgs
 
       describe "" \
-        "What is the API URL for your GitHub Enteprise installation?" \
-        "example: https://github.example.com/api/v3/"
-      prompt_for github_api_url line "GitHub Enterprise API URL:" -i
-      param_entry params github_api_url
-
-      describe "" \
-        "What is the URL used by GitHub Enterprise to generate OAuth Tokens?" \
-        "example: https://github.example.com/login/oauth/access_token"
-      prompt_for github_token_url line "GitHub Enterprise token URL:" -i
-      param_entry params github_token_url
-
-      describe "" \
-        "What is the URL used by GitHub Enterprise to authorize OAuth requests?" \
-        "example: https://github.example.com/login/oauth/authorize"
-      prompt_for github_auth_url line "GitHub Enterprise auth URL:" -i
-      param_entry params github_auth_url
+        "What is the GitHub Enterprise hostname? example: github.example.com"
+      prompt_for github_host line "GitHub Enterprise Hostname:" -i
+      param_entry params github_host
       ;;
 
     "cf-oauth" )


### PR DESCRIPTION
Github Enterprise Oauth only requires github_host now.

https://github.com/concourse/concourse-bosh-release/blob/master/jobs/web/spec#L187-#L215