### PR TITLE
Setting secret_id_ttl to 0 in approle

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Bug Fixes
+
+- Fixed issue with the genesis setup-appole addon to prevent the secret_id from expiring every 90 minutes

--- a/hooks/addon
+++ b/hooks/addon
@@ -238,7 +238,7 @@ setup-approle)
   # - 90 minute TTL (Some BOSH deployments could take awhile, and then the Exodus write-back could fail if TTL is too short)
   # - unlimited token use
   safe --quiet set auth/approle/role/genesis-pipelines \
-    secret_id_ttl=90m \
+    secret_id_ttl=0 \
     token_num_uses=0 \
     token_ttl=90m \
     token_max_ttl=90m \


### PR DESCRIPTION
When secret_id_ttl was set in the approle for concourse pipelines we could only use them for 90m before expiring.