### PR TITLE
Remove unused parameters from CF OAuth addon. 

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -163,11 +163,12 @@ the `cf-oauth` feature flag, and provide the following parameters:
     This parameter is **required**.
 
   - `cf_spaces` - A list of Cloud Foundry space GUIDs.  Developers in those
-    spaces, will be given access to Concourse.
+    spaces, will be given access to Concourse. In the form `ORG:SPACE`.
     This parameter is **required**.
 
   - `cf_ca_cert_vault_path` - The path, in the Vault, to the Cloud Foundry
-    CA certificate.
+    CA certificate. This is usually something like
+    `secret/path/to/keys/for/haproxy/ssl:certificate`
     This parameter is **required**.
 
 The following secrets will be pulled from the vault:

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -162,10 +162,6 @@ the `cf-oauth` feature flag, and provide the following parameters:
     For example: `https://api.sys.your-cf.com`.
     This parameter is **required**.
 
-  - `cf_token_uri` - The UAA Token URL, which is usually something like
-    `https://login.sys.your-cf.com/oauth/token`
-    This parameter is **required**.
-
   - `cf_spaces` - A list of Cloud Foundry space GUIDs.  Developers in those
     spaces, will be given access to Concourse.
     This parameter is **required**.

--- a/hooks/new
+++ b/hooks/new
@@ -101,18 +101,6 @@ if [[ "$kit_type" == "full" ]] ; then
         -V url
       param_entry params cf_api_url
 
-      prompt_for uaa_token_url line \
-        "Cloud Foundry UAA Token URL:" -i \
-        --default "${cf_scheme}://login.system.${cf_base_url}/oauth/token" \
-        -V url
-      param_entry params uaa_token_url
-
-      prompt_for uaa_auth_url line \
-        "Cloud Foundry UAA Auth URL:" -i \
-        --default "${cf_scheme}://login.system.${cf_base_url}/oauth/authorize" \
-        -V url
-      param_entry params uaa_auth_url
-
       describe "" \
         "The Cloud Foundry CA cert is used to authenticate Concourse to the UAA," \
         "so that Concourse can then authorize users after they log into the UAA." \

--- a/manifests/oauth/cf-oauth.yml
+++ b/manifests/oauth/cf-oauth.yml
@@ -14,7 +14,7 @@ meta:
         main_team:
           auth:
             cf:
-              spaces: (( grab params.cf_spaces ))
+              spaces_with_developer_role: (( grab params.cf_spaces ))
         cf_auth:
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))

--- a/manifests/oauth/cf-oauth.yml
+++ b/manifests/oauth/cf-oauth.yml
@@ -3,8 +3,6 @@ params:
   cf_spaces: (( param "Please provide a list of CF space GUIDs whose developers can access Concourse" ))
 
   cf_api_url:            (( param "Please provide the URL to your CF API" ))
-  uaa_token_url:         (( param "Please provide the URL to your UAA Token endpoint" ))
-  uaa_auth_url:          (( param "Please provide the URL to your UAA Auth endpoint" ))
   cf_ca_cert_vault_path: (( param "Please provide the Vault path that contains ca for the Cloud Foundry" ))
 
 

--- a/manifests/oauth/cf-oauth.yml
+++ b/manifests/oauth/cf-oauth.yml
@@ -19,4 +19,5 @@ meta:
           client_id:     (( vault meta.vault "/oauth:provider_key" ))
           client_secret: (( vault meta.vault "/oauth:provider_secret" ))
           api_url:       (( grab params.cf_api_url ))
-          ca_cert:       (( vault params.cf_ca_cert_vault_path ))
+          ca_cert:
+            certificate: (( vault params.cf_ca_cert_vault_path ))

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,19 @@
+# Bug Fixes
+
+* Removed unused params `uaa_token_url` and `uaa_auth_url` from the CF OAuth 
+  addon. 
+* Removed unused param `cf_token_uri` from CF OAuth in the manual. 
+* Changed certificate property from `ca_cert` to `ca_cert.certificate` 
+  in the CF OAuth addon. 
+
+# Core Components
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ | 
+| Concourse | [5.8.0](https://github.com/concourse/concourse-bosh-release/releases/tag/v5.8.0) | Jan 8, 2019 |
+| Postgres | [40](https://github.com/cloudfoundry/postgres-release/releases/tag/v40) | Dec 6, 2019 |
+| bpm | [1.1.6](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.6) | Dec 5, 2019 |
+| Slack Notification Resource | [9](https://github.com/cloudfoundry-community-attic/slack-notification-resource-boshrelease/releases/tag/v9) | Feb 19, 2016 |
+| Shout | [0.1.0](https://github.com/jhunt/shout-boshrelease/releases/tag/v0.1.0) | Sep 3, 2018 |
+| Locker | [0.2.1](https://github.com/cloudfoundry-community/locker-boshrelease/releases/tag/v0.2.1) | May 31, 2017 |
+| HAProxy | [9.8.0](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.8.0) | Oct 4, 2019 |

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,8 @@
+# Changes
+
+* Replaced the deprecated parameter `auth.cf.spaces` with
+  `main_team.auth.cf.spaces_with_developer_role` in Cf OAuth.
+
 # Bug Fixes
 
 * Removed unused params `uaa_token_url` and `uaa_auth_url` from the CF OAuth 


### PR DESCRIPTION
Remove the unused params  `uaa_token_url` and `uaa_auth_url` from the CF OAuth addon. The data that these used to provide is now pulled from the `cf_api_url` endpoint by concourse. Also removed `cf_token_uri` which was cited in the manual, but did not exist in the kit. 

Fixed the incorrect CF OAuth addon parameter `cf_auth.ca_cert.certificate` which was previously `cf_auth.ca_cert`.