### PR TITLE
feature to disable haproxy

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -227,6 +227,13 @@ A `small-footprint` deployment cannot be scaled up to a full-size deployment,
 or vice-versa. Any feature flags that work on the `full` deployment will work
 on `small-footprint` deployment.
 
+# Deploying Without HAProxy
+
+The _no-haproxy_ feature allows you to deploy without an HAProxy. If you're
+migrating from a deployment that isn't using this feature, you may see your
+web node IP shift back one IP spot into the place that the HAProxy would have
+taken.
+
 # Setting Up Vault Integration For Pipelines
 
 The ATC can be configured to pull credentials for pipeline configurations using

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -11,7 +11,8 @@ validate_features \
   workers full small-footprint                  \
   no-tls provided-cert self-signed-cert         \
   github-oauth github-enterprise-oauth cf-oauth \
-  vault vault-approle shout prometheus
+  vault vault-approle shout prometheus          \
+  no-haproxy
 
 if [[ "$(bosh_cpi)" == "azure" ]]; then
   merge+=( "manifests/addons/azure.yml" )
@@ -43,7 +44,6 @@ if want_feature "full" || want_feature "small-footprint"; then
   if want_feature "small-footprint" ; then
     merge+=( "manifests/concourse/small-footprint.yml" )
   fi
-
   for oauth in "github-oauth" "cf-oauth" ; do
     if want_feature "$oauth" ; then
       merge+=( "manifests/oauth/${oauth}.yml" )
@@ -71,6 +71,10 @@ if want_feature "full" || want_feature "small-footprint"; then
       echo >&2
       exit 1
     fi
+  fi
+
+  if want_feature "no-haproxy" && ! want_feature "small-footprint"; then
+    merge+=( "manifests/addons/no-haproxy.yml" )
   fi
 
   if want_feature "vault"; then

--- a/manifests/addons/no-haproxy.yml
+++ b/manifests/addons/no-haproxy.yml
@@ -1,0 +1,10 @@
+---
+- type: remove
+  path: /instance_groups/name=haproxy
+- type: remove
+  path: /meta/jobs/haproxy
+- type: remove
+  path: /releases/name=haproxy
+- type: replace
+  path: /instance_groups/name=web/networks/0/static_ips
+  value: (( static_ips 0, 1, 2, 3, 4 ))

--- a/manifests/concourse/jobs.yml
+++ b/manifests/concourse/jobs.yml
@@ -10,7 +10,7 @@ meta:
           tcp:
             - name: web_http
               port: 80
-              backend_port: 8080
+              backend_port: 80
               backend_servers: (( grab instance_groups.web.networks.0.static_ips || instance_groups.concourse.networks.0.static_ips ))
 
     bpm:
@@ -31,7 +31,7 @@ meta:
             name: atc
             password: (( vault meta.vault "/database/atc:password" ))
         token_signing_key: (( grab params.token_signing_key ))
-        bind_port: 8080
+        bind_port: 80
         publicly_viewable: true
         main_team:
           auth:


### PR DESCRIPTION
the `no-haproxy` feature does what it says, it removes the HAProxy node

For simplicity and consistency, this changes the listening port of the web node to 80 (from 8080) when not using TLS. This is consistent with TLS changing the backend port to 443, and also eliminates the requirement to do this override with an additional file when the no-tls feature is used in conjunction with this one.

This feature also shifts the static IPs of web nodes back one IP, into the spot where an HAProxy would be, such that you don't need two static IPs just to deploy one web node.