### PR TITLE
Don't create database/atc password when external-db included

### DIFF
--- a/hooks/features
+++ b/hooks/features
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "$GENESIS_REQUESTED_FEATURES"
+
+if ! want_feature "external-db" ; then
+  echo "+internal-db"
+fi

--- a/kit.yml
+++ b/kit.yml
@@ -30,9 +30,6 @@ credentials:
     locker/api:
       password: random 16
 
-    database/atc:
-      password: random 64
-
     webui:
       password: random 16 fmt bcrypt
 
@@ -41,6 +38,10 @@ credentials:
       password: random 16
     shout/admin:
       password: random 32
+
+  +internal-db:
+    database/atc:
+      password: random 64
 
 provided:
   github-oauth:


### PR DESCRIPTION
Fixes https://github.com/genesis-community/concourse-genesis-kit/issues/59