### PR TITLE
Allow CRUD under secret path

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -364,6 +364,8 @@ EOF
         echo 'path "'"${concourse_mount%/}/data/*$capabilities"
         echo 'path "'"${concourse_mount%/}/metadata/*$capabilities"
       fi
+    # Allow crud under secret
+      echo 'path "'"secret/*$capabilities"
     )"
     if ! safe --quiet vault policy write concourse - <<< "$policy" >/dev/null 2>&1 ; then
       bail "#R{[error]}" "Failed to save #C{concourse} policy."


### PR DESCRIPTION
Concourse pipelines rely on `safe exists secret/handshake` to confirm connectivity to vault:

```
TRACE ⮀ Setting environment values:
         DEBUG=''
         SAFE_TARGET='https://10.4.1.6'
         
         From directory: /tmp/build/87a8b8e6/dev-changes
         Executing: `safe "$@" 2>&1`
          - with arguments:
            1: 'exists'
            2: '/secret/handshake'
         ⬑  ~/.geese/lib/Genesis.pm:L520 (in Genesis::run)
         
 TRACE ⮀ command duration: 0 seconds
 VALUE ⮀ run_output = '!! 403 Forbidden: 1 error occurred:
                * permission denied'
         ⬑  ~/.geese/lib/Genesis/Vault.pm:L342 (in Genesis::Vault::query)
         
 TRACE ⮀ command exited with status 100 (rc 1)
         ⬑  ~/.geese/lib/Genesis.pm:L545 (in Genesis::run)
         
uninitialized

 DEBUG ⮀ Vault status: uninitialized
 ERROR ⮀ [ERROR] Could not connect to vault
         ⬑  ~/.geese/lib/Genesis/Vault.pm:L262 (in Genesis::Vault::connect_and_validate)
         
[ERROR] Could not connect to vault
```

Although this could be addressed by adding `path "secret/data/handshake"`, the rest of the pipeline requires secrets that are stored under `secret/*`:

```
Verifying availability of vault 'deployments-vault' (https://10.4.1.7)...ok

Preparing to deploy dev:
  - based on kit cf/2.2.0-rc.14
[ERROR] Could not find BOSH director dev
```


 The lines bellow add the following policy line and alone for the pipeline to proceed accordingly

```
path "/secret/*" {                                                               
  capabilities = ["create", "read", "update", "delete", "list", "sudo"]          
} 
```