### PR TITLE
The internal db password cannot be rotated.

### DIFF
--- a/kit.yml
+++ b/kit.yml
@@ -41,7 +41,7 @@ credentials:
 
   +internal-db:
     database/atc:
-      password: random 64
+      password: random 64 fixed
 
 provided:
   github-oauth:


### PR DESCRIPTION
The password is only set on initialization, so changing after that
causes a mismatch.